### PR TITLE
Documentation and typo changes 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # fairmodels 0.2.3
 * Fixed the way the `parity_loss` is calculated in `all_cutoffs` and `ceteris_paribus_cutoff`. (#24)
 * Updated vignettes
+* changed documentation of functions to explicitly state metrics instead of `fairness_check_metrics()`. (#29)
+* Fixed typos (#27 and #28)
+* Changed conclusion drawn from density plot in `Basic Tutorial` (#26)
 
 # fairmodels 0.2.2
 * `fairness_check_data` now instead of `0` has `NA` due to concerns of interpretability - insignificant difference could lead up to maximal value of loss. With that change when `NA` is created user will see warning when plotting or printing. This doesn't affect other objects and plots.

--- a/R/all_cutoffs.R
+++ b/R/all_cutoffs.R
@@ -5,7 +5,7 @@
 #'
 #' @param x object of class \code{fairness_object}
 #' @param grid_points numeric, grid for cutoffs to test. Number of points between 0 and 1 spread evenly
-#' @param fairness_metrics character, name of metric or vector of multiple metrics names
+#' @param fairness_metrics character, name of parity_loss metric or vector of multiple metrics names. Full names can be found in \code{fairness_check} documentation.
 #'
 #' @return \code{all_cutoffs} object, \code{data.frame} containing information about label, metric and parity_loss at particular cutoff
 #' @export
@@ -32,9 +32,7 @@
 #'                           privileged = "male")
 #'
 #'
-#' ac <- all_cutoffs(fobject,
-#'                   fairness_metrics = c("TPR",
-#'                                        "FPR"))
+#' ac <- all_cutoffs(fobject)
 #' plot(ac)
 #'
 

--- a/R/ceteris_paribus_cutoff.R
+++ b/R/ceteris_paribus_cutoff.R
@@ -11,7 +11,7 @@
 #' @param subgroup character, name of subgroup (level in protected variable)
 #' @param new_cutoffs list of cutoffs with names matching those of subgroups. Each value should represent cutoff for particular subgroup.
 #' Position corresponding to subgroups in levels will be changed. Default is NULL
-#' @param fairness_metrics character, name of metric or vector of multiple metrics
+#' @param fairness_metrics character, name of parity_loss metric or vector of multiple metrics, for full metric names check \code{fairness_check} documentation.
 #' @param grid_points numeric, grid for cutoffs to test. Number of points between 0 and 1 spread evenly.
 #' @param cumulated logical, if \code{TRUE}  facets will collapse to one plot and parity loss for each model will be summed. Default \code{FALSE}.
 #'
@@ -50,7 +50,7 @@
 ceteris_paribus_cutoff <- function(x,
                                    subgroup,
                                    new_cutoffs = NULL,
-                                   fairness_metrics = fairness_check_metrics(),
+                                   fairness_metrics = c('ACC', 'TPR', 'PPV', 'FPR', 'STP'),
                                    grid_points = 101,
                                    cumulated = FALSE){
 

--- a/R/choose_metric.R
+++ b/R/choose_metric.R
@@ -8,18 +8,18 @@
 #'
 #' \itemize{
 #'
-#' \item TPR_parity_loss - parity loss of True Positive Rate (Sensitivity, Recall, Equal Odds)
-#' \item TNR_parity_loss - parity loss of True Negative Rate (Specificity)
-#' \item PPV_parity_loss - parity loss of Positive Predictive Value (Precision)
-#' \item NPV_parity_loss - parity loss of Negative Predictive Value
-#' \item FNR_parity_loss - parity loss of False Negative Rate
-#' \item FPR_parity_loss - parity loss of False Positive Rate
-#' \item FDR_parity_loss - parity loss of False Discovery Rate
-#' \item FOR_parity_loss - parity loss of False Omission Rate
-#' \item TS_parity_loss  - parity loss of Threat Score
-#' \item ACC_parity_loss - parity loss of Accuracy
-#' \item STP_parity_loss - parity loss of Statistical Parity
-#' \item F1_parity_loss  - parity loss of F1 Score
+#' \item TPR - parity loss of True Positive Rate (Sensitivity, Recall, Equal Odds)
+#' \item TNR - parity loss of True Negative Rate (Specificity)
+#' \item PPV - parity loss of Positive Predictive Value (Precision)
+#' \item NPV - parity loss of Negative Predictive Value
+#' \item FNR - parity loss of False Negative Rate
+#' \item FPR - parity loss of False Positive Rate
+#' \item FDR - parity loss of False Discovery Rate
+#' \item FOR - parity loss of False Omission Rate
+#' \item TS  - parity loss of Threat Score
+#' \item ACC - parity loss of Accuracy
+#' \item STP - parity loss of Statistical Parity
+#' \item F1  - parity loss of F1 Score
 #' }
 #'
 #'

--- a/R/choose_metric.R
+++ b/R/choose_metric.R
@@ -18,11 +18,10 @@
 #' \item FOR_parity_loss - parity loss of False Omission Rate
 #' \item TS_parity_loss  - parity loss of Threat Score
 #' \item ACC_parity_loss - parity loss of Accuracy
+#' \item STP_parity_loss - parity loss of Statistical Parity
 #' \item F1_parity_loss  - parity loss of F1 Score
-#' \item MCC_parity_loss - parity loss of Matthews correlation coefficient
 #' }
 #'
-#' @details some of metrics give same parity loss as others (for example TPR and FNR and that is because TPR = 1 - FNR)
 #'
 #' @return \code{chosen_metric} object
 #' It is a list with following fields:

--- a/R/fairness_check.R
+++ b/R/fairness_check.R
@@ -379,7 +379,7 @@ fairness_check <- function(x,
     metric <- c(rep("Accuracy equality ratio    (TP + TN)/(TP + FP + TN + FN)", n_sub),
                 rep("Predictive parity ratio     TP/(TP + FP)", n_sub),
                 rep("Predictive equality ratio   FP/(FP + TN)", n_sub),
-                rep("Equal opportynity ratio     TP/(TP + FN)", n_sub),
+                rep("Equal opportunity ratio     TP/(TP + FN)", n_sub),
                 rep("Statistical parity ratio   (TP + FP)/(TP + FP + TN + FN)", n_sub))
 
     score <- c(unlist(accuracy_equality_loss),

--- a/R/fairness_radar.R
+++ b/R/fairness_radar.R
@@ -3,7 +3,7 @@
 #' Make \code{fairness_radar} object with chosen \code{fairness_metrics}. Note that there must be at least three metrics that does not contain NA.
 #'
 #' @param x object of class \code{fairness_object}
-#' @param fairness_metrics character, vector of metric names, at least 3 metrics without NA needed. If \code{NULL} default metrics will be used, which are ones from \code{fairness_check} plot.
+#' @param fairness_metrics character, vector of metric names, at least 3 metrics without NA needed. Full names of metrics can be found in \code{fairness_check} documentation.
 #'
 #' @return \code{fairness_radar} object.
 #' It is a list containing:
@@ -44,7 +44,7 @@
 #' plot(fradar)
 
 
-fairness_radar <- function(x, fairness_metrics = fairness_check_metrics()){
+fairness_radar <- function(x, fairness_metrics = c('ACC', 'TPR', 'PPV', 'FPR', 'STP')){
 
   stopifnot(class(x) == "fairness_object")
 

--- a/R/group_metric.R
+++ b/R/group_metric.R
@@ -5,7 +5,7 @@
 #' privileged and unprivileged subgroups will be measured. When plotted shows both fairness metric and chosen performance metric.
 #'
 #' @param x object of class \code{fairness_object}
-#' @param fairness_metric character, fairness metric name
+#' @param fairness_metric character, fairness metric name, if \code{NULL} the default metric will be used which is TPR.
 #' @param performance_metric character, performance metric name
 #' @param parity_loss logical, if \code{TRUE} parity loss will supersede basic metric
 #' @param verbose logical, whether to print information about metrics on console or not. Default \code{TRUE}
@@ -15,7 +15,7 @@
 #' @details
 #' Available metrics:
 #'
-#' Fairness metrics:
+#' Fairness metrics (Full names explained in \code{fairness_check} documentation):
 #'
 #' \itemize{
 #' \item TPR
@@ -28,6 +28,7 @@
 #' \item FOR
 #' \item TS
 #' \item ACC
+#' \item STP
 #' \item F1
 #' }
 #' Performance metrics

--- a/R/metric_scores.R
+++ b/R/metric_scores.R
@@ -5,7 +5,7 @@
 #' denote the scores for privileged subgroup. It is best to use only few metrics (using \code{fairness_metrics} parameter)
 #'
 #' @param x object of class \code{fairness_object}
-#' @param fairness_metrics character, vector with fairness metric names. Default metrics are ones in \code{fairness_check} plot
+#' @param fairness_metrics character, vector with fairness metric names. Default metrics are ones in \code{fairness_check} plot, full names can be found in \code{fairness_check} documentation.
 #'
 #' @return \code{metric_scores} object.
 #' It is a list containing:
@@ -37,13 +37,13 @@
 #'                           protected = german$Sex,
 #'                           privileged = "male")
 #'
-#' ms <- metric_scores(fobject, fairness_metrics = c("TPR","STP","ACC"))
+#' ms <- metric_scores(fobject, fairness_metrics = c('ACC', 'TPR', 'PPV', 'FPR', 'STP'))
 #' plot(ms)
 #'
 
 
 
-metric_scores <- function(x, fairness_metrics = fairness_check_metrics()){
+metric_scores <- function(x, fairness_metrics = c('ACC', 'TPR', 'PPV', 'FPR', 'STP')){
   stopifnot(class(x) == "fairness_object")
 
   if (! is.character(fairness_metrics)) stop("fairness_metrics must be character vector")

--- a/R/performance_and_fairness.R
+++ b/R/performance_and_fairness.R
@@ -6,7 +6,7 @@
 #' @description Measure performance in both fairness metric and
 #'
 #' @param x object of class \code{fairness_object}
-#' @param fairness_metric fairness metric, one of those in fairness_object
+#' @param fairness_metric fairness metric, one of metrics in fairness_objects parity_loss_metric_data  (ACC, TPR, PPV, ...) Full list in \code{fairness_check} documentation.
 #' @param performance_metric performance metric, one of
 #'
 #' @importFrom DALEX model_performance

--- a/R/stack_metrics.R
+++ b/R/stack_metrics.R
@@ -4,7 +4,7 @@
 #' for subgroups from protected vector.
 #'
 #' @param x object of class \code{fairness_object}
-#' @param fairness_metrics character, vector of fairness metric names to include in plot. Default are ones in fairness check.
+#' @param fairness_metrics character, vector of fairness parity_loss metric names to include in plot. Full names are provided in \code{fairess_check} documentation.
 #'
 #' @return \code{stacked_metrics} object. It contains \code{data.frame} with information about score for each metric and model.
 #'
@@ -41,7 +41,7 @@
 
 
 
-stack_metrics <- function(x, fairness_metrics = fairness_check_metrics() ){
+stack_metrics <- function(x, fairness_metrics = c('ACC', 'TPR', 'PPV', 'FPR', 'STP') ){
 
   stopifnot(class(x) == "fairness_object")
 

--- a/man/all_cutoffs.Rd
+++ b/man/all_cutoffs.Rd
@@ -11,7 +11,7 @@ all_cutoffs(x, grid_points = 101, fairness_metrics = fairness_check_metrics())
 
 \item{grid_points}{numeric, grid for cutoffs to test. Number of points between 0 and 1 spread evenly}
 
-\item{fairness_metrics}{character, name of metric or vector of multiple metrics names}
+\item{fairness_metrics}{character, name of parity_loss metric or vector of multiple metrics names. Full names can be found in \code{fairness_check} documentation.}
 }
 \value{
 \code{all_cutoffs} object, \code{data.frame} containing information about label, metric and parity_loss at particular cutoff
@@ -42,9 +42,7 @@ fobject <- fairness_check(explainer_lm, explainer_rf,
                           privileged = "male")
 
 
-ac <- all_cutoffs(fobject,
-                  fairness_metrics = c("TPR",
-                                       "FPR"))
+ac <- all_cutoffs(fobject)
 plot(ac)
 
 }

--- a/man/ceteris_paribus_cutoff.Rd
+++ b/man/ceteris_paribus_cutoff.Rd
@@ -8,7 +8,7 @@ ceteris_paribus_cutoff(
   x,
   subgroup,
   new_cutoffs = NULL,
-  fairness_metrics = fairness_check_metrics(),
+  fairness_metrics = c("ACC", "TPR", "PPV", "FPR", "STP"),
   grid_points = 101,
   cumulated = FALSE
 )
@@ -21,7 +21,7 @@ ceteris_paribus_cutoff(
 \item{new_cutoffs}{list of cutoffs with names matching those of subgroups. Each value should represent cutoff for particular subgroup.
 Position corresponding to subgroups in levels will be changed. Default is NULL}
 
-\item{fairness_metrics}{character, name of metric or vector of multiple metrics}
+\item{fairness_metrics}{character, name of parity_loss metric or vector of multiple metrics, for full metric names check \code{fairness_check} documentation.}
 
 \item{grid_points}{numeric, grid for cutoffs to test. Number of points between 0 and 1 spread evenly.}
 

--- a/man/choose_metric.Rd
+++ b/man/choose_metric.Rd
@@ -23,8 +23,8 @@ choose_metric(x, fairness_metric = "FPR")
 \item FOR_parity_loss - parity loss of False Omission Rate
 \item TS_parity_loss  - parity loss of Threat Score
 \item ACC_parity_loss - parity loss of Accuracy
+\item STP_parity_loss - parity loss of Statistical Parity
 \item F1_parity_loss  - parity loss of F1 Score
-\item MCC_parity_loss - parity loss of Matthews correlation coefficient
 }}
 }
 \value{
@@ -39,9 +39,6 @@ It is a list with following fields:
 \description{
 Extracts metrics from \code{metric_data} from fairness object.
 It allows to visualize and compare chosen metric values across all models.
-}
-\details{
-some of metrics give same parity loss as others (for example TPR and FNR and that is because TPR = 1 - FNR)
 }
 \examples{
 data("german")

--- a/man/fairness_radar.Rd
+++ b/man/fairness_radar.Rd
@@ -4,12 +4,12 @@
 \alias{fairness_radar}
 \title{Fairness radar}
 \usage{
-fairness_radar(x, fairness_metrics = fairness_check_metrics())
+fairness_radar(x, fairness_metrics = c("ACC", "TPR", "PPV", "FPR", "STP"))
 }
 \arguments{
 \item{x}{object of class \code{fairness_object}}
 
-\item{fairness_metrics}{character, vector of metric names, at least 3 metrics without NA needed. If \code{NULL} default metrics will be used, which are ones from \code{fairness_check} plot.}
+\item{fairness_metrics}{character, vector of metric names, at least 3 metrics without NA needed. Full names of metrics can be found in \code{fairness_check} documentation.}
 }
 \value{
 \code{fairness_radar} object.

--- a/man/group_metric.Rd
+++ b/man/group_metric.Rd
@@ -15,7 +15,7 @@ group_metric(
 \arguments{
 \item{x}{object of class \code{fairness_object}}
 
-\item{fairness_metric}{character, fairness metric name}
+\item{fairness_metric}{character, fairness metric name, if \code{NULL} the default metric will be used which is TPR.}
 
 \item{performance_metric}{character, performance metric name}
 
@@ -42,7 +42,7 @@ privileged and unprivileged subgroups will be measured. When plotted shows both 
 \details{
 Available metrics:
 
-Fairness metrics:
+Fairness metrics (Full names explained in \code{fairness_check} documentation):
 
 \itemize{
 \item TPR
@@ -55,6 +55,7 @@ Fairness metrics:
 \item FOR
 \item TS
 \item ACC
+\item STP
 \item F1
 }
 Performance metrics

--- a/man/metric_scores.Rd
+++ b/man/metric_scores.Rd
@@ -4,12 +4,12 @@
 \alias{metric_scores}
 \title{Metric scores}
 \usage{
-metric_scores(x, fairness_metrics = fairness_check_metrics())
+metric_scores(x, fairness_metrics = c("ACC", "TPR", "PPV", "FPR", "STP"))
 }
 \arguments{
 \item{x}{object of class \code{fairness_object}}
 
-\item{fairness_metrics}{character, vector with fairness metric names. Default metrics are ones in \code{fairness_check} plot}
+\item{fairness_metrics}{character, vector with fairness metric names. Default metrics are ones in \code{fairness_check} plot, full names can be found in \code{fairness_check} documentation.}
 }
 \value{
 \code{metric_scores} object.
@@ -46,7 +46,7 @@ fobject <- fairness_check(explainer_lm, explainer_rf,
                           protected = german$Sex,
                           privileged = "male")
 
-ms <- metric_scores(fobject, fairness_metrics = c("TPR","STP","ACC"))
+ms <- metric_scores(fobject, fairness_metrics = c('ACC', 'TPR', 'PPV', 'FPR', 'STP'))
 plot(ms)
 
 }

--- a/man/performance_and_fairness.Rd
+++ b/man/performance_and_fairness.Rd
@@ -9,7 +9,7 @@ performance_and_fairness(x, fairness_metric = NULL, performance_metric = NULL)
 \arguments{
 \item{x}{object of class \code{fairness_object}}
 
-\item{fairness_metric}{fairness metric, one of those in fairness_object}
+\item{fairness_metric}{fairness metric, one of metrics in fairness_objects parity_loss_metric_data  (ACC, TPR, PPV, ...) Full list in \code{fairness_check} documentation.}
 
 \item{performance_metric}{performance metric, one of}
 }

--- a/man/plot_stacked_barplot.Rd
+++ b/man/plot_stacked_barplot.Rd
@@ -4,12 +4,12 @@
 \alias{stack_metrics}
 \title{Stack metrics}
 \usage{
-stack_metrics(x, fairness_metrics = fairness_check_metrics())
+stack_metrics(x, fairness_metrics = c("ACC", "TPR", "PPV", "FPR", "STP"))
 }
 \arguments{
 \item{x}{object of class \code{fairness_object}}
 
-\item{fairness_metrics}{character, vector of fairness metric names to include in plot. Default are ones in fairness check.}
+\item{fairness_metrics}{character, vector of fairness parity_loss metric names to include in plot. Full names are provided in \code{fairess_check} documentation.}
 }
 \value{
 \code{stacked_metrics} object. It contains \code{data.frame} with information about score for each metric and model.

--- a/tests/testthat/test_fairness_check.R
+++ b/tests/testthat/test_fairness_check.R
@@ -76,7 +76,7 @@ test_that("Test fairness_check", {
   suppressWarnings(expect_error(fairness_check(fobject, fobject2, privileged = "Female", protected = compas$Sex)))
 
   # good calculations
-  calculated_val_TPR <- fobject$fairness_check_data[fobject$fairness_check_data$model == "lm" & fobject$fairness_check_data$metric == 'Equal opportynity ratio     TP/(TP + FN)', "score" ]
+  calculated_val_TPR <- fobject$fairness_check_data[fobject$fairness_check_data$model == "lm" & fobject$fairness_check_data$metric == 'Equal opportunity ratio     TP/(TP + FN)', "score" ]
   calculated_val_FPR <- fobject$fairness_check_data[fobject$fairness_check_data$model == "lm" & fobject$fairness_check_data$metric == 'Predictive equality ratio   FP/(FP + TN)', "score" ]
   calculated_val_PPV <- fobject$fairness_check_data[fobject$fairness_check_data$model == "lm" & fobject$fairness_check_data$metric == 'Predictive parity ratio     TP/(TP + FP)', "score" ]
   calculated_val_STP <- fobject$fairness_check_data[fobject$fairness_check_data$model == "lm" & fobject$fairness_check_data$metric == 'Statistical parity ratio   (TP + FP)/(TP + FP + TN + FN)', "score" ]

--- a/vignettes/Basic_tutorial.Rmd
+++ b/vignettes/Basic_tutorial.Rmd
@@ -106,7 +106,7 @@ Why do we have this bias? Model did learn from biased data. We can see it on plo
 plot_density(fobject)
 ```
    
-As we can see it is more likely that model will categorize African Americans as not being recidivists than for example Asians. 
+As we can see it is more likely that model will categorize African Americans as being recidivists than for example Asians. 
 
 ### Metric scores plot
 Sometimes it is worth it to see what the raw (unscaled) metrics are. User could use `fobject$group_data` but the easier way is to plot `metric_scores` object.

--- a/vignettes/Basic_tutorial.Rmd
+++ b/vignettes/Basic_tutorial.Rmd
@@ -109,7 +109,7 @@ plot_density(fobject)
 As we can see it is more likely that model will categorize African Americans as being recidivists than for example Asians. 
 
 ### Metric scores plot
-Sometimes it is worth it to see what the raw (unscaled) metrics are. User could use `fobject$group_data` but the easier way is to plot `metric_scores` object.
+Sometimes it is worth it to see what the raw (unscaled) metrics are. User could use `fobject$groups_data` but the easier way is to plot `metric_scores` object.
 
 ```{r}
 plot(metric_scores(fobject))


### PR DESCRIPTION
* changed documentation of functions to explicitly state metrics instead of `fairness_check_metrics()`. (#29)
* Fixed typos (#27 and #28)
* Changed conclusion drawn from density plot in `Basic Tutorial` (#26)